### PR TITLE
Support for visual range with `:Isort`

### DIFF
--- a/ftplugin/python_vimisort.vim
+++ b/ftplugin/python_vimisort.vim
@@ -8,7 +8,12 @@ else
     throw 'No python support present, vim-isort will be disabled'
 endif
 
-command! Isort exec("AvailablePython isort_file()")
+
+fun! ISort(start, end)
+    exe "AvailablePython isort(vim.current.buffer.range(".a:start.",".a:end."))"
+endfun
+command! -range=% Isort keepjumps call ISort(<line1>,<line2>)
+
 
 if !exists('g:vim_isort_map')
     let g:vim_isort_map = '<C-i>'
@@ -17,6 +22,7 @@ endif
 if g:vim_isort_map != ''
     execute "vnoremap <buffer>" g:vim_isort_map s:available_short_python "isort_visual()<CR>"
 endif
+
 
 AvailablePython <<EOF
 import vim


### PR DESCRIPTION
This would make the extra Python functions unnecessary, but I've left
them, as with the old mapping for visual mode.

Feel free to improve upon. I would also like to not have the mapping
(i.e. a setting for it). Given how easy `:Is<tab><cr>` is (and the
number of times you use it), it should not overwrite an existing
default Vim shortcut.

/cc https://github.com/fisadev/vim-isort/pull/3
