### PR TITLE
Use the `Plugin` command instead of `Bundle`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Installation
 
 .. code::
 
-    Bundle 'fisadev/vim-isort'
+    Plugin 'fisadev/vim-isort'
 
 (Or if you don't use any plugin manager, you can just copy the ``python_vimisort.vim`` file to your ``.vim/ftplugin`` folder)
 


### PR DESCRIPTION
This was changed in Vundle in March 2014: http://git.io/vL4KV