### PR TITLE
Add ability to specify Python version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,3 +44,9 @@ Or disable the mapping with this:
 .. code-block:: viml
 
     let g:vim_isort_map = ''
+
+You can also specify a particular Python version, so if `isort` is installed under Python 3:
+
+.. code-block:: viml
+
+    let g:vim_isort_python_version = 'python3'

--- a/ftplugin/python_vimisort.vim
+++ b/ftplugin/python_vimisort.vim
@@ -1,11 +1,21 @@
-if has('python')
-    command! -nargs=1 AvailablePython python <args>
-    let s:available_short_python = ':py'
-elseif has('python3')
-    command! -nargs=1 AvailablePython python3 <args>
-    let s:available_short_python = ':py3'
+if exists('g:vim_isort_python_version')
+    if g:vim_isort_python_version ==? 'python2'
+        command! -nargs=1 AvailablePython python <args>
+        let s:available_short_python = ':py'
+    elseif g:vim_isort_python_version ==? 'python3'
+        command! -nargs=1 AvailablePython python3 <args>
+        let s:available_short_python = ':py3'
+    endif
 else
-    throw 'No python support present, vim-isort will be disabled'
+    if has('python')
+        command! -nargs=1 AvailablePython python <args>
+        let s:available_short_python = ':py'
+    elseif has('python3')
+        command! -nargs=1 AvailablePython python3 <args>
+        let s:available_short_python = ':py3'
+    else
+        throw 'No python support present, vim-isort will be disabled'
+    endif
 endif
 
 command! Isort exec("AvailablePython isort_file()")


### PR DESCRIPTION
I run Python version 2 and 3 on my system. I have most packages installed under Python 3, including `isort`. Without the ability to tell `vim-isort` to look for `isort` under Python 3, it cannot find it.