### PR TITLE
Fixed the error when the file is skipped

### DIFF
--- a/ftplugin/python_vimisort.vim
+++ b/ftplugin/python_vimisort.vim
@@ -67,7 +67,15 @@ def isort(text_range):
     if using_bytes:
         old_text = old_text.decode('utf-8')
 
-    new_text = SortImports(file_contents=old_text).output
+    sorted_imports = SortImports(file_contents=old_text)
+
+    # In developement version there will be `.skipped` flag added:
+    # https://github.com/timothycrosley/isort/blob/develop/isort/isort.py?#L118
+    # But for now, we can just check for the `output` property.
+    if not getattr(sorted_imports, 'output', ''):
+        return
+
+    new_text = sorted_imports.output
 
     if using_bytes:
         new_text = new_text.encode('utf-8')


### PR DESCRIPTION
Hey, I just noticed that when the file is manually skipped i.e. `isort:skip_file` "token" in the file, the plugin will throw the annoying error like this:

<img width="573" alt="screen shot 2017-11-17 at 12 30 30" src="https://user-images.githubusercontent.com/306862/32947317-318f70ae-cb93-11e7-8eaa-031d072393c4.png">

I just added a check for that to exit if there is no output (which usually means that the data wasn't processed i.e. skipped).
