### PR TITLE
Account for isort:skip_file

### DIFF
--- a/ftplugin/python_vimisort.vim
+++ b/ftplugin/python_vimisort.vim
@@ -68,6 +68,9 @@ def isort(text_range):
         old_text = old_text.decode('utf-8')
 
     new_text = SortImports(file_contents=old_text).output
+    
+    if new_text is None:
+        return
 
     if using_bytes:
         new_text = new_text.encode('utf-8')


### PR DESCRIPTION
Currently `SortImports(file_contents=old_text).output` returns None if `isort:skip_file` is present within the file being edited. This causes the `new_lines = new_text.split('\n')` a couple lines down to error with a `AttributeError: 'NoneType' object has no attribute 'split'` error. This guards against it.