### PR TITLE
Do not rewrite buffer if nothing is changed.

### DIFF
--- a/ftplugin/python_vimisort.vim
+++ b/ftplugin/python_vimisort.vim
@@ -68,8 +68,8 @@ def isort(text_range):
         old_text = old_text.decode('utf-8')
 
     new_text = SortImports(file_contents=old_text).output
-    
-    if new_text is None:
+
+    if new_text is None or old_text == new_text:
         return
 
     if using_bytes:


### PR DESCRIPTION
I want to use isort on each save/write to file therefore I use following configuration:

:autocmd BufWritePre *.py :Isort

This has one problem however. Even if nothing is changed my cursor jumps back to the beginning of file. This is not ideal fix but it is better than nothing. I think ideal fix would save and restore cursor position.
