### PR TITLE
Added g:vim_isort_config_overrides

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,8 +49,8 @@ You can configure overrides for isort's config parameters:
 
 .. code-block:: viml
 
-    let g:vim_isort_config_overrides = {'include_trailing_comma': 1,
-                                       \ 'multi_line_output': 3}
+    let g:vim_isort_config_overrides = {
+      \ 'include_trailing_comma': 1, 'multi_line_output': 3}
 
 You can also specify a particular Python version, so if `isort` is installed under Python 3:
 

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,13 @@ Or disable the mapping with this:
 
     let g:vim_isort_map = ''
 
+You can configure overrides for isort's config parameters:
+
+.. code-block:: viml
+
+    let g:vim_isort_config_overrides = {'include_trailing_comma': 1,
+                                       \ 'multi_line_output': 3}
+
 You can also specify a particular Python version, so if `isort` is installed under Python 3:
 
 .. code-block:: viml

--- a/ftplugin/python_vimisort.vim
+++ b/ftplugin/python_vimisort.vim
@@ -67,7 +67,7 @@ def isort(text_range):
 
     config_overrides = vim.eval('g:vim_isort_config_overrides')
     if not isinstance(config_overrides, dict):
-        print('g:vim_isort_config_overrides should be dict, found {}'.format(type(overrides)))
+        print('g:vim_isort_config_overrides should be dict, found {}'.format(type(config_overrides)))
         return
     # convert ints carried over from vim as strings
     config_overrides = {k: int(v) if isinstance(v, str) and v.isdigit() else v


### PR DESCRIPTION
This adds the ability to set `g:vim_isort_config_overrides` to a dict containing parameters that will override the default or configured parameters of isort. This is useful for those who want different options enabled when using isort from vim or who just don't want to maintain an isort config.