### PR TITLE
BugFix: ValueError

### DIFF
--- a/ftplugin/python_vimisort.vim
+++ b/ftplugin/python_vimisort.vim
@@ -89,7 +89,10 @@ def isort(text_range):
         old_text = old_text.decode('utf-8')
 
     if code is not None:
-        new_text = code(old_text, config=Config(settings_path=os.getcwd()), **config_overrides)
+        if config_overrides:
+            new_text = code(old_text, **config_overrides)
+        else:
+            new_text = code(old_text, config=Config(settings_path=os.getcwd()))
     else:
         new_text = SortImports(file_contents=old_text, **config_overrides).output
 


### PR DESCRIPTION
Set the g: vim_isort_config_overrides parameter to vimrc and it crashed with the message: "ValueError: You can either specify custom configuration options using kwargs or passing in a Config object. Not Both!"