### PR TITLE
improve the relative import code from plugin/python_vimisort.vim

### DIFF
--- a/plugin/python_vimisort.vim
+++ b/plugin/python_vimisort.vim
@@ -1,1 +1,1 @@
-../ftplugin/python_vimisort.vim
+execute 'source' expand('<sfile>:p:h') . expand('/../ftplugin/python_vimisort.vim')


### PR DESCRIPTION
The code:
`plugin/python_vimisort.vim`:
```
../ftplugin/python_vimisort.vim
```
Doesn't seems to work fine on Windows 10 / Vim 9.1
I propose to replace it by:
```
execute 'source' expand('<sfile>:p:h') . expand('/../ftplugin/python_vimisort.vim')
```